### PR TITLE
Allowing mozilla slider colors to change

### DIFF
--- a/src/components/Progress.module.css
+++ b/src/components/Progress.module.css
@@ -34,7 +34,7 @@
   width: 20px;
   height: 20px;
   border-radius: 50%;
-  background: #b951e9;
+  background: var(--progressSlider);
   cursor: pointer;
 }
 

--- a/src/components/Volume.module.css
+++ b/src/components/Volume.module.css
@@ -35,7 +35,7 @@
   width: 20px;
   height: 20px;
   border-radius: 50%;
-  background: #b951e9;
+  background: var(--volumeSlider);
   cursor: pointer;
 }
 


### PR DESCRIPTION
When using Firefox, I noticed that the css variable does not allow the slider thumbs to change